### PR TITLE
Implement basic common concept enums

### DIFF
--- a/src/ele_quant/__init__.py
+++ b/src/ele_quant/__init__.py
@@ -1,5 +1,6 @@
 """Utilities for the Elements of Quantitative Investing project."""
 
 from .utils import slugify
+from . import common_concepts
 
-__all__ = ["slugify"]
+__all__ = ["slugify", "common_concepts"]

--- a/src/ele_quant/common_concepts/__init__.py
+++ b/src/ele_quant/common_concepts/__init__.py
@@ -1,0 +1,19 @@
+"""Common financial concept definitions used across the library."""
+
+from .enumerations import (
+    SecurityType,
+    ExchangeMode,
+    MarketParticipantSide,
+    SellSideParticipantRole,
+    BuySideParticipantRole,
+)
+from .participants import MarketParticipant
+
+__all__ = [
+    "SecurityType",
+    "ExchangeMode",
+    "MarketParticipantSide",
+    "SellSideParticipantRole",
+    "BuySideParticipantRole",
+    "MarketParticipant",
+]

--- a/src/ele_quant/common_concepts/enumerations.py
+++ b/src/ele_quant/common_concepts/enumerations.py
@@ -1,0 +1,55 @@
+from enum import Enum
+
+__all__ = [
+    "SecurityType",
+    "ExchangeMode",
+    "MarketParticipantSide",
+    "SellSideParticipantRole",
+    "BuySideParticipantRole",
+]
+
+
+class SecurityType(Enum):
+    """Enumeration of security types."""
+
+    EQUITY = "EQUITY"
+    ETF = "ETF"
+    FUTURE = "FUTURE"
+    BOND = "BOND"
+    OPTION = "OPTION"
+    INTEREST_RATE_SWAP = "INTEREST_RATE_SWAP"
+    CREDIT_DEFAULT_SWAP = "CREDIT_DEFAULT_SWAP"
+
+
+class ExchangeMode(Enum):
+    """Enumeration of trading venues."""
+
+    EXCHANGE = "EXCHANGE"
+    OTC = "OTC"
+    DARK_POOL = "DARK_POOL"
+
+
+class MarketParticipantSide(Enum):
+    """Market participant sides."""
+
+    SELL_SIDE = "SELL_SIDE"
+    BUY_SIDE = "BUY_SIDE"
+
+
+class SellSideParticipantRole(Enum):
+    """Roles for sell-side participants."""
+
+    DEALER = "DEALER"
+    BROKER = "BROKER"
+    BROKER_DEALER = "BROKER_DEALER"
+
+
+class BuySideParticipantRole(Enum):
+    """Roles for buy-side participants."""
+
+    PASSIVE_INSTITUTIONAL = "PASSIVE_INSTITUTIONAL"
+    HEDGER = "HEDGER"
+    INSTITUTIONAL_ACTIVE_MANAGER = "INSTITUTIONAL_ACTIVE_MANAGER"
+    ASSET_ALLOCATOR = "ASSET_ALLOCATOR"
+    INFORMED_TRADER = "INFORMED_TRADER"
+    RETAIL_INVESTOR = "RETAIL_INVESTOR"

--- a/src/ele_quant/common_concepts/participants.py
+++ b/src/ele_quant/common_concepts/participants.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from .enumerations import (
+    BuySideParticipantRole,
+    MarketParticipantSide,
+    SellSideParticipantRole,
+)
+
+__all__ = ["MarketParticipant"]
+
+
+class MarketParticipant:
+    """Simple representation of a market participant."""
+
+    def __init__(
+        self,
+        side: MarketParticipantSide,
+        role: Union[SellSideParticipantRole, BuySideParticipantRole],
+        name: Optional[str] = None,
+    ) -> None:
+        if not isinstance(side, MarketParticipantSide):
+            raise TypeError("side must be MarketParticipantSide")
+        if not isinstance(role, (SellSideParticipantRole, BuySideParticipantRole)):
+            raise TypeError("role must be SellSideParticipantRole or BuySideParticipantRole")
+        self.side = side
+        self.role = role
+        self.name = name
+
+    def describe_role(self) -> str:
+        """Return a textual description of the participant's role."""
+
+        return self.role.name
+
+    def __repr__(self) -> str:  # pragma: no cover - simple representation
+        name_part = f"{self.name}: " if self.name else ""
+        return f"MarketParticipant({name_part}{self.side.name}, {self.role.name})"

--- a/tests/test_common_concepts.py
+++ b/tests/test_common_concepts.py
@@ -1,0 +1,33 @@
+from ele_quant.common_concepts import (
+    SecurityType,
+    ExchangeMode,
+    MarketParticipantSide,
+    SellSideParticipantRole,
+    BuySideParticipantRole,
+    MarketParticipant,
+)
+import pytest
+
+
+def test_enum_members():
+    assert SecurityType.EQUITY.name == "EQUITY"
+    assert ExchangeMode.OTC.name == "OTC"
+    assert MarketParticipantSide.SELL_SIDE.name == "SELL_SIDE"
+    assert SellSideParticipantRole.BROKER.name == "BROKER"
+    assert BuySideParticipantRole.RETAIL_INVESTOR.name == "RETAIL_INVESTOR"
+
+
+def test_market_participant_creation():
+    mp = MarketParticipant(
+        MarketParticipantSide.BUY_SIDE,
+        BuySideParticipantRole.RETAIL_INVESTOR,
+        name="Alice",
+    )
+    assert mp.side is MarketParticipantSide.BUY_SIDE
+    assert mp.role is BuySideParticipantRole.RETAIL_INVESTOR
+    assert mp.name == "Alice"
+
+
+def test_market_participant_invalid_role():
+    with pytest.raises(TypeError):
+        MarketParticipant(MarketParticipantSide.BUY_SIDE, "Trader")


### PR DESCRIPTION
## Summary
- implement enumerations for core financial concepts
- add a simple `MarketParticipant` class
- expose new module via package `__init__`
- add unit tests for enums and market participant

## Testing
- `pytest -q`
